### PR TITLE
Fix some bugs found by shared device tests

### DIFF
--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -34,8 +34,6 @@ Code details
 """
 import abc
 
-import numpy as np
-
 import qsharp
 
 from pennylane import Device

--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -114,6 +114,7 @@ class QSharpDevice(Device):
 
         super().__init__(wires, shots)
         self.reset()
+        self.analytic = False
 
     @property
     def source(self):
@@ -137,7 +138,7 @@ class QSharpDevice(Device):
             device_wires = self.map_wires(e.wires)
 
             self.measure += "set resultArray w/= {wires[0]} <- ".format(wires=device_wires.tolist())
-            self.measure += self._observable_map[e.name].format(p=e.parameters, wires=device_wires.tolist())
+            self.measure += self._observable_map[e.name].format(wires=device_wires.tolist())
             self.measure += "            "
 
         self._source_code = PROGRAM.format(wires=self.num_wires, operations=self.prog, measurements=self.measure)

--- a/pennylane_qsharp/quantum_simulator.py
+++ b/pennylane_qsharp/quantum_simulator.py
@@ -56,7 +56,11 @@ class QuantumSimulatorDevice(QSharpDevice):
             self.results.append([1-2*int(i) for i in self.qs.simulate()])
 
     def expval(self, observable, wires, par):
-        return np.mean(np.array(self.results).T[wires[0]])
+        # translate the user wire labels to device wire labels
+        device_wires = self.map_wires(wires)
+        return np.mean(np.array(self.results).T[device_wires.labels[0]])
 
     def var(self, observable, wires, par):
-        return np.var(np.array(self.results).T[wires[0]])
+        # translate the user wire labels to device wire labels
+        device_wires = self.map_wires(wires)
+        return np.var(np.array(self.results).T[device_wires.labels[0]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 qsharp
-pennylane>=0.6.0
+pennylane>=0.11.0
 sphinx-automodapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 qsharp
-pennylane>=0.11.0
+pennylane>=0.6.0
 sphinx-automodapi


### PR DESCRIPTION
This PR attempts to fix the following bug appearing from running the shared device test suite: 

```
../PennyLane-qsharp/pennylane_qsharp/device.py:142: in post_apply
    self.measure += self._observable_map[e.name].format(p=e.parameters, wires=device_wires.tolist())
E   ValueError: Single '}' encountered in format string
```

It also adds an ``analytic`` attribute to the device (which is always false in this simulator), and fixes an oversight of the previous wires refactor in PR #10. 


