### PR TITLE
Update deprecated Q# syntax

### DIFF
--- a/pennylane_qsharp/device.py
+++ b/pennylane_qsharp/device.py
@@ -46,8 +46,8 @@ open Microsoft.Quantum.Convert;
 open Microsoft.Quantum.Measurement;
 
 operation Program () : Bool[] {{
-    mutable resultArray = new Result[{wires}];
-    using (q = Qubit[{wires}]) {{
+    mutable resultArray = [Zero, size = {wires}];
+    use q = Qubit[{wires}] {{
         // operations
         {operations}
         // measurements


### PR DESCRIPTION
Fixes the following deprecation warnings:

```
warning QS3308: Deprecated syntax. Use [] to construct an empty array, or [x, size = n] to construct an array of x repeated n times.
warning QS3306: Deprecated syntax. Parentheses here are no longer required and will not be supported in the future.
warning QS3307: The "using" keyword has been replaced with "use", and qubits may now be allocated without a block. Consider "use q = Qubit();" or "use q = Qubit() { ... }".
```