### PR TITLE
Updated ReadTheDocs badge to new url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 PennyLane Q# Plugin
 ###################
 
-.. image:: https://img.shields.io/readthedocs/pennylane-qiskit.svg?logo=read-the-docs&style=popout-square
+.. image:: https://readthedocs.com/projects/xanaduai-pennylane-qsharp/badge/?version=latest&style=flat-square
     :alt: Read the Docs
-    :target: https://pennylaneqsharp.readthedocs.io
+    :target: https://docs.pennylane.ai/projects/qsharp
 
 .. header-start-inclusion-marker-do-not-remove
 


### PR DESCRIPTION
**Context:** New ReadTheDocs badge

**Description of the Change:**
The current RTD badge on the pennylane-qsharp README uses https://shield.io/, which unfortunately does not support the Business tier hosting of RTD.

The new solution is to use the badge that RTD themselves generate for each project.

This PR updates the RTD docs badge with the new links.

**Benefits:**
Old badge will go stale once the current community RTD builds are disabled. This new badge reflects the updated status.

**Possible Drawbacks:**
No logo available with the new badge

**Related GitHub Issues:**
None.