### PR TITLE
Switch to GA4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PennyLane-Q#'
-copyright = "2022, Xanadu Quantum Technologies"
+copyright = "2023, Xanadu Quantum Technologies"
 author = 'Xanadu'
 
 add_module_names = False
@@ -249,7 +249,7 @@ html_theme_options = {
     ],
     "toc_overview": True,
     "navbar_active_link": 3,
-    "google_analytics_tracking_id": "UA-130507810-1"
+    "google_analytics_tracking_id": "G-C480Z9JL0D"
 }
 
 edit_on_github_project = 'PennyLaneAI/PennyLane-qsharp'


### PR DESCRIPTION
Google is deprecating Universal Analytics on July 1st. This PR switches to the newer GA4 tag.